### PR TITLE
fix: added arm64 support for prisma, required to run Docker images in…

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "debian-openssl-1.1.x"]
+  binaryTargets = ["native", "debian-openssl-1.1.x", "linux-arm64-openssl-1.1.x"]
   output        = "../src/generated/client"
 }
 


### PR DESCRIPTION
Hi!

I built this app for new Raspberry pi's, they have arm64/v8 cpu architectures. With this binary target added, images can work in those cpus too.

Thank you for the great app!